### PR TITLE
Set max line length for lll linter from configuration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -323,10 +323,12 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/gogo/protobuf/types",
     "github.com/kami-zh/go-capturer",
     "github.com/kelseyhightower/envconfig",
     "github.com/sanity-io/litter",
     "github.com/src-d/lookout",
+    "github.com/src-d/lookout/pb",
     "github.com/src-d/lookout/util/grpchelper",
     "github.com/stretchr/testify/require",
     "google.golang.org/grpc",

--- a/analyzer.go
+++ b/analyzer.go
@@ -2,11 +2,14 @@ package gometalint
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
+	types "github.com/gogo/protobuf/types"
 	"github.com/src-d/lookout"
 	log "gopkg.in/src-d/go-log.v1"
 )
@@ -21,6 +24,39 @@ type Analyzer struct {
 }
 
 var _ lookout.AnalyzerServer = &Analyzer{}
+
+// function to convert pb.types.Value to string argument
+type argumentConstructor func(v *types.Value) string
+
+// map of linters with options and argument constructors
+var lintersOptions = map[string]map[string]argumentConstructor{
+	"lll": map[string]argumentConstructor{
+		"maxLen": func(v *types.Value) string {
+			var number int
+
+			switch v.GetKind().(type) {
+			case *types.Value_StringValue:
+				n, err := strconv.Atoi(v.GetStringValue())
+				if err != nil {
+					log.Warningf("wrong type for lll:maxLen argument")
+					return ""
+				}
+				number = n
+			case *types.Value_NumberValue:
+				number = int(v.GetNumberValue())
+			default:
+				log.Warningf("wrong type for lll:maxLen argument")
+				return ""
+			}
+
+			if number < 1 {
+				return ""
+			}
+
+			return fmt.Sprintf("--line-length=%d", number)
+		},
+	},
+}
 
 func (a *Analyzer) NotifyReviewEvent(ctx context.Context, e *lookout.ReviewEvent) (
 	*lookout.EventResponse, error) {
@@ -67,7 +103,7 @@ func (a *Analyzer) NotifyReviewEvent(ctx context.Context, e *lookout.ReviewEvent
 		return &lookout.EventResponse{AnalyzerVersion: a.Version}, nil
 	}
 
-	withArgs := append(a.Args, tmp)
+	withArgs := append(append(a.Args, tmp), a.linterArguments(e.Configuration)...)
 	comments := RunGometalinter(withArgs)
 	var allComments []*lookout.Comment
 	for _, comment := range comments {
@@ -105,4 +141,68 @@ func tryToSaveTo(file *lookout.File, tmp string) {
 }
 func (a *Analyzer) NotifyPushEvent(ctx context.Context, e *lookout.PushEvent) (*lookout.EventResponse, error) {
 	return &lookout.EventResponse{}, nil
+}
+
+func (a *Analyzer) linterArguments(s types.Struct) []string {
+	config := s.GetFields()
+	if config == nil {
+		return nil
+	}
+
+	clStruct, ok := config["linters"]
+	if !ok || clStruct == nil {
+		return nil
+	}
+
+	lintersListValue := clStruct.GetListValue()
+	if lintersListValue == nil {
+		return nil
+	}
+
+	var args []string
+
+	for _, v := range lintersListValue.GetValues() {
+		if v == nil {
+			continue
+		}
+
+		sv := v.GetStructValue()
+		if sv == nil {
+			continue
+		}
+
+		fields := sv.GetFields()
+		nameV, ok := fields["name"]
+		if !ok || nameV == nil {
+			continue
+		}
+
+		name := nameV.GetStringValue()
+		correctLinter := false
+		for linter := range lintersOptions {
+			if name == linter {
+				correctLinter = true
+			}
+		}
+
+		if !correctLinter {
+			log.Warningf("unknown linter %s", name)
+			continue
+		}
+
+		linterOpts := lintersOptions[name]
+		for optionName := range linterOpts {
+			optV, ok := fields[optionName]
+			if !ok || optV == nil {
+				continue
+			}
+
+			arg := linterOpts[optionName](optV)
+			if arg != "" {
+				args = append(args, arg)
+			}
+		}
+	}
+
+	return args
 }

--- a/analyzer_test.go
+++ b/analyzer_test.go
@@ -1,0 +1,77 @@
+package gometalint
+
+import (
+	"testing"
+
+	types "github.com/gogo/protobuf/types"
+	"github.com/src-d/lookout/pb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArgsEmpty(t *testing.T) {
+	require := require.New(t)
+
+	inputs := []types.Struct{
+		types.Struct{},
+		*pb.ToStruct(map[string]interface{}{
+			"linters": []map[string]interface{}{},
+		}),
+		*pb.ToStruct(map[string]interface{}{
+			"linters": []map[string]interface{}{
+				{
+					"name":   "unknown",
+					"maxLen": 120,
+				},
+			},
+		}),
+		*pb.ToStruct(map[string]interface{}{
+			"linters": []map[string]interface{}{
+				{
+					"name": "lll",
+				},
+			},
+		}),
+		*pb.ToStruct(map[string]interface{}{
+			"linters": []map[string]interface{}{
+				{
+					"name":   "lll",
+					"maxLen": "not a number",
+				},
+			},
+		}),
+		*pb.ToStruct(map[string]interface{}{
+			"linters": []map[string]interface{}{
+				{
+					"name":   "lll",
+					"maxLen": 120.1,
+				},
+			},
+		}),
+	}
+
+	a := Analyzer{}
+	for _, input := range inputs {
+		require.Len(a.linterArguments(input), 0)
+	}
+}
+
+func TestArgsCorrect(t *testing.T) {
+	a := Analyzer{}
+	require.Equal(t, []string{"--line-length=120"}, a.linterArguments(*pb.ToStruct(map[string]interface{}{
+		"linters": []map[string]interface{}{
+			{
+				"name":   "lll",
+				"maxLen": "120",
+			},
+		},
+	})))
+
+	require.Equal(t, []string{"--line-length=120"}, a.linterArguments(*pb.ToStruct(map[string]interface{}{
+		"linters": []map[string]interface{}{
+			{
+				"name":   "lll",
+				"maxLen": 120,
+			},
+		},
+	})))
+}


### PR DESCRIPTION
fix: #5

`pb.Struct` api in go quite verbose without helpers. But I think it's better to implement such helper in sdk, not here.