### PR TITLE
Separate release and deploy stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ stages:
   - name: test
   - name: release
     if: tag IS present
+  - name: deploy
+    if: tag IS present
 
 go_import_path: github.com/src-d/lookout-gometalint-analyzer
 
@@ -54,7 +56,7 @@ jobs:
         - PKG_OS=linux make packages
         - DOCKER_PUSH_LATEST=true make docker-push
     - name: 'Deploy to staging'
-      stage: release
+      stage: deploy
       install:
         - make install-helm
       script:


### PR DESCRIPTION
Stage jobs are run in parallel and we don't want as helm needs the
docker image to be pushed. Furthermore Travis does not run any stage job
if a job from the previous stage has failed which is exactly what we
want.

Signed-off-by: Rafael Porres Molina <rafa@sourced.tech>