### PR TITLE
ci: fix integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       script:
         - curl https://raw.githubusercontent.com/src-d/lookout-sdk/master/_tools/install-lookout-latest.sh | bash
         - (./build/lookout-gometalint-analyzer_linux_amd64/gometalint-analyzer 2>&1 | tee -a analyzer.log)&
-        - ./lookout-sdk review -v "ipv4://localhost:2001" --from="86466b69281ca6bdcbc55413014ddb5a5ac4ce50" --to="a044e568d6b3bd6bf5ecf49fdd8c170de53fcb73"
+        - ./lookout-sdk review "ipv4://localhost:2001" --from="86466b69281ca6bdcbc55413014ddb5a5ac4ce50" --to="a044e568d6b3bd6bf5ecf49fdd8c170de53fcb73"
 
     - name: 'Check deps'
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       script:
         - curl https://raw.githubusercontent.com/src-d/lookout-sdk/master/_tools/install-lookout-latest.sh | bash
         - (./build/lookout-gometalint-analyzer_linux_amd64/gometalint-analyzer 2>&1 | tee -a analyzer.log)&
-        - ./lookout-sdk --log-level=debug review "ipv4://localhost:2001" --from="86466b69281ca6bdcbc55413014ddb5a5ac4ce50" --to="a044e568d6b3bd6bf5ecf49fdd8c170de53fcb73"
+        - ./lookout-sdk review --log-level=debug "ipv4://localhost:2001" --from="86466b69281ca6bdcbc55413014ddb5a5ac4ce50" --to="a044e568d6b3bd6bf5ecf49fdd8c170de53fcb73"
 
     - name: 'Check deps'
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       script:
         - curl https://raw.githubusercontent.com/src-d/lookout-sdk/master/_tools/install-lookout-latest.sh | bash
         - (./build/lookout-gometalint-analyzer_linux_amd64/gometalint-analyzer 2>&1 | tee -a analyzer.log)&
-        - ./lookout-sdk review "ipv4://localhost:2001" --from="86466b69281ca6bdcbc55413014ddb5a5ac4ce50" --to="a044e568d6b3bd6bf5ecf49fdd8c170de53fcb73"
+        - ./lookout-sdk --log-level=debug review "ipv4://localhost:2001" --from="86466b69281ca6bdcbc55413014ddb5a5ac4ce50" --to="a044e568d6b3bd6bf5ecf49fdd8c170de53fcb73"
 
     - name: 'Check deps'
       install:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ With `lookout-sdk` binary from the latest release of [SDK](https://github.com/sr
 ```
 $ lookout-gometalint
 
-$ lookout-sdk review -v ipv4://localhost:2001 \
+$ lookout-sdk review --log-level=debug ipv4://localhost:2001 \
     --from c99dcdff172f1cb5505603a45d054998cb4dd606 \
     --to 3a9d78bdd1139c929903885ecb8f811931b8aa70
 ```


### PR DESCRIPTION
Most probably related to https://github.com/src-d/lookout/pull/378

Fixes CI failure from https://github.com/src-d/lookout-gometalint-analyzer/pull/19