### PR TITLE
update default port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       script:
         - curl https://raw.githubusercontent.com/src-d/lookout-sdk/master/_tools/install-lookout-latest.sh | bash
         - (./build/lookout-gometalint-analyzer_linux_amd64/gometalint-analyzer 2>&1 | tee -a analyzer.log)&
-        - ./lookout-sdk review --log-level=debug "ipv4://localhost:2001" --from="86466b69281ca6bdcbc55413014ddb5a5ac4ce50" --to="a044e568d6b3bd6bf5ecf49fdd8c170de53fcb73"
+        - ./lookout-sdk review --log-level=debug --from="86466b69281ca6bdcbc55413014ddb5a5ac4ce50" --to="a044e568d6b3bd6bf5ecf49fdd8c170de53fcb73"
 
     - name: 'Check deps'
       install:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ With `lookout-sdk` binary from the latest release of [SDK](https://github.com/sr
 ```
 $ lookout-gometalint
 
-$ lookout-sdk review --log-level=debug ipv4://localhost:2001 \
+$ lookout-sdk review --log-level=debug \
     --from c99dcdff172f1cb5505603a45d054998cb4dd606 \
     --to 3a9d78bdd1139c929903885ecb8f811931b8aa70
 ```
@@ -53,7 +53,7 @@ $ lookout-sdk review --log-level=debug ipv4://localhost:2001 \
 | Variable | Default | Description |
 | -- | -- | -- |
 | `GOMETALINT_HOST` | `0.0.0.0` | IP address to bind the gRCP serve |
-| `GOMETALINT_PORT` | `2001` | Port to bind the gRPC server |
+| `GOMETALINT_PORT` | `9930` | Port to bind the gRPC server |
 | `GOMETALINT_DATA_SERVICE_URL` | `ipv4://localhost:10301` | gRPC URL of the [Data service](https://github.com/src-d/lookout/tree/master/docs#components)
 | `GOMETALINT_LOG_LEVEL` | `info` | Logging level ("info", "debug", "warning" or "error") |
 

--- a/cmd/gometalint-analyzer/main.go
+++ b/cmd/gometalint-analyzer/main.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/src-d/lookout-gometalint-analyzer"
+	gometalint "github.com/src-d/lookout-gometalint-analyzer"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/sanity-io/litter"
@@ -30,7 +30,7 @@ var (
 
 type config struct {
 	Host           string `envconfig:"HOST" default:"0.0.0.0"`
-	Port           int    `envconfig:"PORT" default:"2001"`
+	Port           int    `envconfig:"PORT" default:"9930"`
 	DataServiceURL string `envconfig:"DATA_SERVICE_URL" default:"ipv4://localhost:10301"`
 	LogLevel       string `envconfig:"LOG_LEVEL" default:"info" description:"Logging level (info, debug, warning or error)"`
 }


### PR DESCRIPTION
CI suppose to fail as long as we don't release new sdk version.
It's done intentionally to make sure default in sdk and in the analyzer are the same.

Ref: https://github.com/src-d/lookout/issues/350

Signed-off-by: Maxim Sukharev <max@smacker.ru>