### PR TITLE
Update travis badge to new .com url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [![Build Status](https://travis-ci.org/src-d/lookout-gometalint-analyzer.svg)](https://travis-ci.org/src-d/lookout-gometalint-analyzer) lookout analyzer: gometalint
+# [![Build Status](https://travis-ci.com/src-d/lookout-gometalint-analyzer.svg?branch=master)](https://travis-ci.com/src-d/lookout-gometalint-analyzer) lookout analyzer: gometalint
 
 A [lookout](https://github.com/src-d/lookout/) analyzer implementation that
 uses [gometalinter](https://github.com/alecthomas/gometalinter).


### PR DESCRIPTION
The current badge does not report the build status correctly, and links to travis.org, which is not where the build happen anymore.